### PR TITLE
feat: support amazon bedrock deepseek-r1 model

### DIFF
--- a/react-native/src/api/bedrock-api.ts
+++ b/react-native/src/api/bedrock-api.ts
@@ -27,7 +27,7 @@ import {
 } from '../chat/util/BedrockMessageConvertor.ts';
 import { invokeOpenAIWithCallBack } from './open-api.ts';
 import { invokeOllamaWithCallBack } from './ollama-api.ts';
-import { BedrockThinkingModels } from '../storage/Constants.ts';
+import { BedrockThinkingModels, DeepSeekModels } from '../storage/Constants.ts';
 
 type CallbackFunction = (
   result: string,
@@ -45,7 +45,9 @@ export const invokeBedrockWithCallBack = async (
   controller: AbortController,
   callback: CallbackFunction
 ) => {
-  const isDeepSeek = getTextModel().modelId.includes('deepseek');
+  const isDeepSeek = DeepSeekModels.some(
+    model => model.modelId === getTextModel().modelId
+  );
   const isOpenAI = getTextModel().modelId.includes('gpt');
   const isOllama = getTextModel().modelId.startsWith('ollama-');
   if (chatMode === ChatMode.Text && (isDeepSeek || isOpenAI || isOllama)) {

--- a/react-native/src/api/open-api.ts
+++ b/react-native/src/api/open-api.ts
@@ -195,8 +195,7 @@ const parseStreamData = (chunk: string, lastChunk: string = '') => {
           modelName: getTextModel().modelName,
           inputTokens:
             parsedData.usage.prompt_tokens -
-            (Math.floor((3 / 4) * parsedData.usage.prompt_cache_hit_tokens) ??
-              0),
+            (parsedData.usage.prompt_cache_hit_tokens ?? 0),
           outputTokens: parsedData.usage.completion_tokens,
           totalTokens: parsedData.usage.total_tokens,
         };

--- a/react-native/src/api/open-api.ts
+++ b/react-native/src/api/open-api.ts
@@ -195,7 +195,8 @@ const parseStreamData = (chunk: string, lastChunk: string = '') => {
           modelName: getTextModel().modelName,
           inputTokens:
             parsedData.usage.prompt_tokens -
-            (parsedData.usage.prompt_cache_hit_tokens ?? 0),
+            (Math.floor((3 / 4) * parsedData.usage.prompt_cache_hit_tokens) ??
+              0),
           outputTokens: parsedData.usage.completion_tokens,
           totalTokens: parsedData.usage.total_tokens,
         };

--- a/react-native/src/chat/component/CustomMessageComponent.tsx
+++ b/react-native/src/chat/component/CustomMessageComponent.tsx
@@ -31,6 +31,8 @@ import { isMac } from '../../App.tsx';
 import { CustomTokenizer } from './markdown/CustomTokenizer.ts';
 import { State, TapGestureHandler } from 'react-native-gesture-handler';
 import Markdown from './markdown/Markdown.tsx';
+import { DeepSeekModels } from '../../storage/Constants.ts';
+import { getTextModel } from '../../storage/StorageUtils.ts';
 
 interface CustomMessageProps extends MessageProps<SwiftChatMessage> {
   chatStatus: ChatStatus;
@@ -78,7 +80,9 @@ const CustomMessageComponent: React.FC<CustomMessageProps> = ({
       currentMessage.user._id === 1
         ? 'You'
         : currentMessage.user.name ?? 'Bedrock';
-    const isDeepSeek = userName.includes('DeepSeek');
+    const isDeepSeek = DeepSeekModels.some(
+      model => model.modelId === getTextModel().modelId
+    );
     const isOpenAI = userName.includes('GPT');
     const isOllama = userName.includes(':');
 

--- a/react-native/src/chat/component/EmptyChatComponent.tsx
+++ b/react-native/src/chat/component/EmptyChatComponent.tsx
@@ -11,6 +11,7 @@ import { useNavigation } from '@react-navigation/native';
 import { RouteParamList } from '../../types/RouteTypes.ts';
 import { DrawerNavigationProp } from '@react-navigation/drawer';
 import { getTextModel } from '../../storage/StorageUtils.ts';
+import { DeepSeekModels } from '../../storage/Constants.ts';
 
 const isAndroid = Platform.OS === 'android';
 type NavigationProp = DrawerNavigationProp<RouteParamList>;
@@ -23,7 +24,9 @@ export const EmptyChatComponent = ({
   chatMode,
 }: EmptyChatComponentProps): React.ReactElement => {
   const navigation = useNavigation<NavigationProp>();
-  const isDeepSeek = getTextModel().modelId.includes('deepseek');
+  const isDeepSeek = DeepSeekModels.some(
+    model => model.modelId === getTextModel().modelId
+  );
   const isOpenAI = getTextModel().modelId.includes('gpt');
   const isOllama = getTextModel().modelId.startsWith('ollama-');
   const modelIcon = isDeepSeek

--- a/react-native/src/chat/component/markdown/useMarkdown.ts
+++ b/react-native/src/chat/component/markdown/useMarkdown.ts
@@ -113,7 +113,7 @@ const useMarkdown = (
       }
     }
     combinedText += newContent;
-    if (lastToken.type === 'space') {
+    if (lastToken.type === 'space' && lastTokenIndex > 0) {
       combinedText =
         cacheRef.current.cachedTokens[lastTokenIndex - 1].raw + combinedText;
     }

--- a/react-native/src/settings/ModelPrice.ts
+++ b/react-native/src/settings/ModelPrice.ts
@@ -1,4 +1,4 @@
-import { Usage, UsagePrice } from '../types/Chat.ts';
+import { Model, Usage, UsagePrice } from '../types/Chat.ts';
 
 export const getUsagePrice = (usage: Usage): UsagePrice => {
   const usagePrice: UsagePrice = {
@@ -81,6 +81,10 @@ function getImagePrice(
 
 export const ModelPrice: ModelPriceType = {
   textModelPrices: {
+    'Bedrock DeepSeek-R1': {
+      inputTokenPrice: 0.00135,
+      outputTokenPrice: 0.0054,
+    },
     'DeepSeek-V3': {
       inputTokenPrice: 0.00027,
       outputTokenPrice: 0.0011,
@@ -371,4 +375,15 @@ export function getTotalImagePrice(usage: Usage[]) {
       )
       .toFixed(6)
   );
+}
+
+export function addBedrockPrefixToDeepseekModels(models: Model[]): void {
+  for (let i = 0; i < models.length; i++) {
+    if (models[i].modelName.toLowerCase().includes('deepseek')) {
+      models[i] = {
+        ...models[i],
+        modelName: `Bedrock ${models[i].modelName}`,
+      };
+    }
+  }
 }

--- a/react-native/src/storage/Constants.ts
+++ b/react-native/src/storage/Constants.ts
@@ -1,4 +1,5 @@
 import { Model, SystemPrompt } from '../types/Chat.ts';
+import { getDeepSeekApiKey, getOpenAIApiKey } from './StorageUtils.ts';
 
 const RegionList = [
   'us-west-2',
@@ -28,13 +29,11 @@ export const DeepSeekModels = [
 
 export const BedrockThinkingModels = ['Claude 3.7 Sonnet'];
 
-const DefaultTextModel = [
+export const DefaultTextModel = [
   {
     modelName: 'Nova Pro',
     modelId: 'us.amazon.nova-pro-v1:0',
   },
-  ...DeepSeekModels,
-  ...GPTModels,
 ];
 
 const DefaultImageModel = {
@@ -78,7 +77,14 @@ export function getAllRegions() {
 }
 
 export function getDefaultTextModels() {
-  return DefaultTextModel as Model[];
+  return [...DefaultTextModel, ...getDefaultApiKeyModels()] as Model[];
+}
+
+export function getDefaultApiKeyModels() {
+  return [
+    ...(getDeepSeekApiKey().length > 0 ? DeepSeekModels : []),
+    ...(getOpenAIApiKey().length > 0 ? GPTModels : []),
+  ] as Model[];
 }
 
 export function getDefaultImageModels() {


### PR DESCRIPTION
## Description
1. Add amazon bedrock deepseek-r1 model support
2. Support `deepseek-r1` model price display in usage page
3. Update Settings page, only display the corresponding models in the dropdown list when filling in OpenAI and DeepSeek API keys.
4. Fix the issue for the first token is space

## General Checklist
<!-- Check or cross out if not relevant -->

- [x] The code changes have been fully tested
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of the least privilege, etc.)
- [x] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [x] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT-0 license.
