### PR TITLE
fix: show s3 cp errors instead of silent exit

### DIFF
--- a/server/install.sh
+++ b/server/install.sh
@@ -162,7 +162,7 @@ EOF
 (cd "$SRC_DIR" && zip -qr "$SRC_ZIP" .)
 (cd "$BUILDSPEC_DIR" && zip -q "$SRC_ZIP" buildspec.yml)
 rm -rf "$BUILDSPEC_DIR"
-aws s3 cp "$SRC_ZIP" "s3://${S3_BUCKET}/build/src.zip" --region "$REGION" --quiet
+aws s3 cp "$SRC_ZIP" "s3://${S3_BUCKET}/build/src.zip" --region "$REGION" --only-show-errors
 rm -f "$SRC_ZIP"
 
 # CodeBuild role (create if missing). Propagation is handled by retrying create-project below.


### PR DESCRIPTION
## Issue \#
fix: show s3 cp errors instead of silent exit

## Description
<!-- Why is this change required? What problem does it solve? -->

## General Checklist
<!-- Check or cross out if not relevant -->

- [x] The code changes have been fully tested
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of the least privilege, etc.)
- [x] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [x] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT-0 license.
